### PR TITLE
Add support for generating getters that return Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ There are a number of configuration options supported in the `avro` block.
 | option                    | default               | description                                           |
 | --------------------------| --------------------- | -------------------------------------------------     |
 | createSetters             | `true`                | `createSetters` passed to Avro compiler               |
+| createOptionalGetters     | `false`               | `createOptionalGetters` passed to Avro compiler       |
+| gettersReturnOptional     | `false`               | `gettersReturnOptional` passed to Avro compiler
 | fieldVisibility           | `"PUBLIC_DEPRECATED"` | `fieldVisibility` passed to Avro compiler             |
 | outputCharacterEncoding   | see below             | `outputCharacterEncoding` passed to Avro compiler     |
 | stringType                | `"String"`            | `stringType` passed to Avro compiler                  |
@@ -105,6 +107,40 @@ Example:
 ```groovy
 avro {
     createSetters = false
+}
+```
+
+## createOptionalGetters
+
+Valid values: `false` (default), `true`; supports equivalent `String` values
+
+Set to `true` to create additional getter methods that return their fields wrapped in an
+[Optional](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html). For a field with
+name `abc` and type `string`, this setting will create a method
+`Optional<java.lang.String> getOptionalAbc()`.
+
+Example:
+
+```groovy
+avro {
+    createOptionalGetters = false
+}
+```
+
+## gettersReturnOptional
+
+Valid values: `false` (default), `true`; supports equivalent `String` values
+
+Set to `true` to cause getter methods to return
+[Optional](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html) wrappers of the
+underlying type. Where [`createOptionalGetters`](#createoptionalgetters) generates an additional
+method, this one replaces the existing getter.
+
+Example:
+
+```groovy
+avro {
+    gettersReturnOptional = false
 }
 ```
 

--- a/src/main/java/com/commercehub/gradle/plugin/avro/AvroBasePlugin.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/AvroBasePlugin.java
@@ -36,6 +36,8 @@ public class AvroBasePlugin implements Plugin<Project> {
             configurePropertyConvention(task.getFieldVisibility(), avroExtension.getFieldVisibility());
             configurePropertyConvention(task.getTemplateDirectory(), avroExtension.getTemplateDirectory());
             configurePropertyConvention(task.isCreateSetters(), avroExtension.isCreateSetters());
+            configurePropertyConvention(task.isCreateOptionalGetters(), avroExtension.isCreateOptionalGetters());
+            configurePropertyConvention(task.isGettersReturnOptional(), avroExtension.isGettersReturnOptional());
             configurePropertyConvention(task.isEnableDecimalLogicalType(), avroExtension.isEnableDecimalLogicalType());
             configurePropertyConvention(task.getDateTimeLogicalType(), avroExtension.getDateTimeLogicalType());
         });

--- a/src/main/java/com/commercehub/gradle/plugin/avro/AvroExtension.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/AvroExtension.java
@@ -23,6 +23,8 @@ public interface AvroExtension {
     Property<String> getFieldVisibility();
     Property<String> getTemplateDirectory();
     Property<Boolean> isCreateSetters();
+    Property<Boolean> isCreateOptionalGetters();
+    Property<Boolean> isGettersReturnOptional();
     Property<Boolean> isEnableDecimalLogicalType();
     Property<String> getDateTimeLogicalType();
 }

--- a/src/main/java/com/commercehub/gradle/plugin/avro/Constants.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/Constants.java
@@ -31,6 +31,8 @@ class Constants {
     static final String DEFAULT_STRING_TYPE = StringType.String.name();
     static final String DEFAULT_FIELD_VISIBILITY = FieldVisibility.PUBLIC_DEPRECATED.name();
     static final boolean DEFAULT_CREATE_SETTERS = true;
+    static final boolean DEFAULT_CREATE_OPTIONAL_GETTERS = false;
+    static final boolean DEFAULT_GETTERS_RETURN_OPTIONAL = false;
     static final boolean DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE = true;
     static final String DEFAULT_DATE_TIME_LOGICAL_TYPE = SpecificCompiler.DateTimeLogicalTypeImplementation.DEFAULT.name();
 

--- a/src/main/java/com/commercehub/gradle/plugin/avro/DefaultAvroExtension.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/DefaultAvroExtension.java
@@ -22,10 +22,12 @@ import org.apache.avro.generic.GenericData;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 
+import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_CREATE_OPTIONAL_GETTERS;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_CREATE_SETTERS;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_DATE_TIME_LOGICAL_TYPE;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_FIELD_VISIBILITY;
+import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_GETTERS_RETURN_OPTIONAL;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_STRING_TYPE;
 import static com.commercehub.gradle.plugin.avro.GradleCompatibility.configurePropertyConvention;
 
@@ -35,6 +37,8 @@ public class DefaultAvroExtension implements AvroExtension {
     private final Property<String> fieldVisibility;
     private final Property<String> templateDirectory;
     private final Property<Boolean> createSetters;
+    private final Property<Boolean> createOptionalGetters;
+    private final Property<Boolean> gettersReturnOptional;
     private final Property<Boolean> enableDecimalLogicalType;
     private final Property<String> dateTimeLogicalType;
 
@@ -45,6 +49,8 @@ public class DefaultAvroExtension implements AvroExtension {
         this.fieldVisibility = configurePropertyConvention(objects.property(String.class), DEFAULT_FIELD_VISIBILITY);
         this.templateDirectory = objects.property(String.class);
         this.createSetters = configurePropertyConvention(objects.property(Boolean.class), DEFAULT_CREATE_SETTERS);
+        this.createOptionalGetters = configurePropertyConvention(objects.property(Boolean.class), DEFAULT_CREATE_OPTIONAL_GETTERS);
+        this.gettersReturnOptional = configurePropertyConvention(objects.property(Boolean.class), DEFAULT_GETTERS_RETURN_OPTIONAL);
         this.enableDecimalLogicalType = configurePropertyConvention(objects.property(Boolean.class), DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE);
         this.dateTimeLogicalType = configurePropertyConvention(objects.property(String.class), DEFAULT_DATE_TIME_LOGICAL_TYPE);
     }
@@ -108,6 +114,32 @@ public class DefaultAvroExtension implements AvroExtension {
 
     public void setCreateSetters(boolean createSetters) {
         this.createSetters.set(createSetters);
+    }
+
+    @Override
+    public Property<Boolean> isCreateOptionalGetters() {
+        return createOptionalGetters;
+    }
+
+    public void setCreateOptionalGetters(String createOptionalGetters) {
+        setCreateOptionalGetters(Boolean.parseBoolean(createOptionalGetters));
+    }
+
+    public void setCreateOptionalGetters(boolean createOptionalGetters) {
+        this.createOptionalGetters.set(createOptionalGetters);
+    }
+
+    @Override
+    public Property<Boolean> isGettersReturnOptional() {
+        return gettersReturnOptional;
+    }
+
+    public void setGettersReturnOptional(String gettersReturnOptional) {
+        setGettersReturnOptional(Boolean.parseBoolean(gettersReturnOptional));
+    }
+
+    public void setGettersReturnOptional(boolean gettersReturnOptional) {
+        this.gettersReturnOptional.set(gettersReturnOptional);
     }
 
     @Override

--- a/src/main/java/com/commercehub/gradle/plugin/avro/GenerateAvroJavaTask.java
+++ b/src/main/java/com/commercehub/gradle/plugin/avro/GenerateAvroJavaTask.java
@@ -41,10 +41,12 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 
+import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_CREATE_OPTIONAL_GETTERS;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_CREATE_SETTERS;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_DATE_TIME_LOGICAL_TYPE;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_FIELD_VISIBILITY;
+import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_GETTERS_RETURN_OPTIONAL;
 import static com.commercehub.gradle.plugin.avro.Constants.DEFAULT_STRING_TYPE;
 import static com.commercehub.gradle.plugin.avro.Constants.OPTION_DATE_TIME_LOGICAL_TYPE;
 import static com.commercehub.gradle.plugin.avro.Constants.OPTION_FIELD_VISIBILITY;
@@ -68,6 +70,8 @@ public class GenerateAvroJavaTask extends OutputDirTask {
     private final Property<String> stringType;
     private final Property<String> fieldVisibility;
     private final Property<String> templateDirectory;
+    private final Property<Boolean> createOptionalGetters;
+    private final Property<Boolean> gettersReturnOptional;
     private final Property<Boolean> createSetters;
     private final Property<Boolean> enableDecimalLogicalType;
     private final Property<String> dateTimeLogicalType;
@@ -83,6 +87,8 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         this.stringType = configurePropertyConvention(objects.property(String.class), DEFAULT_STRING_TYPE);
         this.fieldVisibility = configurePropertyConvention(objects.property(String.class), DEFAULT_FIELD_VISIBILITY);
         this.templateDirectory = objects.property(String.class);
+        this.createOptionalGetters = configurePropertyConvention(objects.property(Boolean.class), DEFAULT_CREATE_OPTIONAL_GETTERS);
+        this.gettersReturnOptional = configurePropertyConvention(objects.property(Boolean.class), DEFAULT_GETTERS_RETURN_OPTIONAL);
         this.createSetters = configurePropertyConvention(objects.property(Boolean.class), DEFAULT_CREATE_SETTERS);
         this.enableDecimalLogicalType = configurePropertyConvention(objects.property(Boolean.class), DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE);
         this.dateTimeLogicalType = configurePropertyConvention(objects.property(String.class), DEFAULT_DATE_TIME_LOGICAL_TYPE);
@@ -158,6 +164,32 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         this.createSetters.set(Boolean.parseBoolean(createSetters));
     }
 
+    public Property<Boolean> isCreateOptionalGetters() {
+        return createOptionalGetters;
+    }
+
+    @Input
+    public Property<Boolean> getCreateOptionalGetters() {
+        return createOptionalGetters;
+    }
+
+    public void setCreateOptionalGetters(String createOptionalGetters) {
+        this.createOptionalGetters.set(Boolean.parseBoolean(createOptionalGetters));
+    }
+
+    public Property<Boolean> isGettersReturnOptional() {
+        return gettersReturnOptional;
+    }
+
+    @Input
+    public Property<Boolean> getGettersReturnOptional() {
+        return gettersReturnOptional;
+    }
+
+    public void setGettersReturnOptional(String gettersReturnOptional) {
+        this.gettersReturnOptional.set(Boolean.parseBoolean(gettersReturnOptional));
+    }
+
     public Property<Boolean> isEnableDecimalLogicalType() {
         return enableDecimalLogicalType;
     }
@@ -192,6 +224,8 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         getLogger().debug("Using fieldVisibility {}", fieldVisibilityProvider.get().name());
         getLogger().debug("Using templateDirectory '{}'", getTemplateDirectory().getOrNull());
         getLogger().debug("Using createSetters {}", isCreateSetters().get());
+        getLogger().debug("Using createOptionalGetters {}", isCreateOptionalGetters().get());
+        getLogger().debug("Using gettersReturnOptional {}", isGettersReturnOptional().get());
         getLogger().debug("Using enableDecimalLogicalType {}", isEnableDecimalLogicalType().get());
         getLogger().debug("Using dateTimeLogicalType {}", dateTimeLogicalTypeImplementationProvider.get().name());
         getLogger().info("Found {} files", getInputs().getSourceFiles().getFiles().size());
@@ -315,6 +349,8 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         if (getTemplateDirectory().isPresent()) {
             compiler.setTemplateDir(getTemplateDirectory().get());
         }
+        compiler.setCreateOptionalGetters(createOptionalGetters.get());
+        compiler.setGettersReturnOptional(gettersReturnOptional.get());
         compiler.setCreateSetters(isCreateSetters().get());
         compiler.setEnableDecimalLogicalType(isEnableDecimalLogicalType().get());
 

--- a/src/test/groovy/com/commercehub/gradle/plugin/avro/OptionsFunctionalSpec.groovy
+++ b/src/test/groovy/com/commercehub/gradle/plugin/avro/OptionsFunctionalSpec.groovy
@@ -58,6 +58,12 @@ class OptionsFunctionalSpec extends FunctionalSpec {
         and: "createSetters is enabled"
         content.contains("public void setName(java.lang.String value)")
 
+        and: "createOptionalGetters is disabled"
+        !content.contains("Optional")
+
+        and: "gettersReturnOptional is disabled"
+        !content.contains("Optional")
+
         and: "enableDecimalLogicalType is enabled"
         content.contains("public void setSalary(${BigDecimal.name} value)")
 
@@ -151,6 +157,66 @@ class OptionsFunctionalSpec extends FunctionalSpec {
         "false"         | false
         "'true'"        | true
         "'false'"       | false
+    }
+
+    @Unroll
+    def "supports configuring createOptionalGetters to #createOptionalGetters"() {
+        given:
+        copyResource("user.avsc", avroDir)
+        buildFile << """
+        |avro {
+        |    createOptionalGetters = ${createOptionalGetters}
+        |}
+        |""".stripMargin()
+
+        when:
+        def result = run("generateAvroJava")
+
+        then: "the task succeeds"
+        taskInfoAbsent || result.task(":generateAvroJava").outcome == SUCCESS
+        def content = projectFile("build/generated-main-avro-java/example/avro/User.java").text
+
+        and: "the specified createOptionalGetters is used"
+        content.contains("public Optional<java.lang.String> getOptionalFavoriteColor()") == expectedPresent
+
+        where:
+        createOptionalGetters | expectedPresent
+        "Boolean.TRUE"        | true
+        "Boolean.FALSE"       | false
+        "true"                | true
+        "false"               | false
+        "'true'"              | true
+        "'false'"             | false
+    }
+
+    @Unroll
+    def "supports configuring gettersReturnOptional to #gettersReturnOptional"() {
+        given:
+        copyResource("user.avsc", avroDir)
+        buildFile << """
+        |avro {
+        |    gettersReturnOptional = ${gettersReturnOptional}
+        |}
+        |""".stripMargin()
+
+        when:
+        def result = run("generateAvroJava")
+
+        then: "the task succeeds"
+        taskInfoAbsent || result.task(":generateAvroJava").outcome == SUCCESS
+        def content = projectFile("build/generated-main-avro-java/example/avro/User.java").text
+
+        and: "the specified createOptionalGetters is used"
+        content.contains("public Optional<java.lang.String> getFavoriteColor()") == expectedPresent
+
+        where:
+        gettersReturnOptional | expectedPresent
+        "Boolean.TRUE"        | true
+        "Boolean.FALSE"       | false
+        "true"                | true
+        "false"               | false
+        "'true'"              | true
+        "'false'"             | false
     }
 
     def "supports configuring templateDirectory"() {


### PR DESCRIPTION
This change adds support for the `createOptionalGetters` and `gettersReturnOptional` properties in `SpecificCompiler`, new as of Avro 1.9. 

`createOptionalGetters` adds additional methods of the form `Optional<sometype> getOptionalField()` for each field.

`gettersReturnOptional` changes getters to return `Optional`, as in `Optional<sometype> getField()`.