### PR TITLE
update to Avro 1.9.2 to fix AVRO-2548

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
     jcenter()
 }
 
-def compileAvroVersion = "1.9.1"
+def compileAvroVersion = "1.9.2"
 
 dependencies {
     compile localGroovy()
@@ -183,7 +183,7 @@ test {
 // Java 8+ is also required by Gradle 5.x
 sourceCompatibility = 8
 
-def avroVersions = ["1.9.0", "1.9.1"]
+def avroVersions = ["1.9.0", "1.9.1", "1.9.2"]
 def gradleVersions = []
 if (!org.gradle.api.JavaVersion.current().isJava11Compatible()) { // Gradle 4.8 appears to be the first version that supports Java 11, as per https://github.com/gradle/gradle/pull/4759 and testing
     gradleVersions.addAll("4.4", "4.4.1", "4.5", "4.5.1", "4.6", "4.7")

--- a/src/test/groovy/com/commercehub/gradle/plugin/avro/CustomConversionFunctionalSpec.groovy
+++ b/src/test/groovy/com/commercehub/gradle/plugin/avro/CustomConversionFunctionalSpec.groovy
@@ -15,7 +15,10 @@
  */
 package com.commercehub.gradle.plugin.avro
 
+import spock.lang.Requires
+
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+import static org.gradle.util.GradleVersion.version
 
 class CustomConversionFunctionalSpec extends FunctionalSpec {
     def "setup"() {
@@ -30,6 +33,43 @@ class CustomConversionFunctionalSpec extends FunctionalSpec {
             "com/commercehub/gradle/plugin/avro/test/custom/TimeZoneLogicalType.java")
         copyFile("src/test/java", destDir,
             "com/commercehub/gradle/plugin/avro/test/custom/TimeZoneLogicalTypeFactory.java")
+    }
+
+    @Requires({ version(avroVersion).compareTo(version("1.9.2")) >= 0 })
+    def "can use a custom conversion when generating java from a schema with stringType = \"String\""() {
+        // since Avro 1.9.2 https://issues.apache.org/jira/browse/AVRO-2548 is fixed
+        given:
+        copyResource("customConversion.avsc", avroDir)
+        buildFile << """
+            import com.commercehub.gradle.plugin.avro.test.custom.*
+            avro {
+                stringType = "String"
+                logicalTypeFactory("timezone", TimeZoneLogicalTypeFactory)
+                customConversion(TimeZoneConversion)
+            }
+        """
+        testProjectDir.newFolder("buildSrc")
+        testProjectDir.newFile("buildSrc/build.gradle") << """
+            repositories {
+                jcenter()
+            }
+            dependencies {
+                compile "org.apache.avro:avro:${avroVersion}"
+            }
+        """
+        copyCustomConversion("buildSrc/src/main/java")
+        copyCustomConversion("src/main/java")
+
+        when:
+        def result = run()
+
+        then:
+        taskInfoAbsent || result.task(":generateAvroJava").outcome == SUCCESS
+        taskInfoAbsent || result.task(":compileJava").outcome == SUCCESS
+        projectFile(buildOutputClassPath("test/Event.class")).file
+        def javaSource = projectFile("build/generated-main-avro-java/test/Event.java").text
+        javaSource.contains("java.time.Instant start;")
+        javaSource.contains("java.util.TimeZone timezone;")
     }
 
     def "can use a custom conversion when generating java from a schema"() {


### PR DESCRIPTION
AVRO-2548 has been fixed in 1.9.2.

So simple upgrade plus added a test to proof `stringType = "String"` now works.