### PR TITLE
Throw error if avpr will be overwritten

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Avro 1.9.0-1.9.2 is supported again (no changed needed; just change in support policy and testing)
+* `generateAvroProtocol` task fails if avpr file will get overwritten (due to mutliple IDL files using the same namespace and protocol)
 
 ## 1.1.0
 * Built using Avro 1.10.2

--- a/src/main/java/com/github/davidmc24/gradle/plugin/avro/GenerateAvroProtocolTask.java
+++ b/src/main/java/com/github/davidmc24/gradle/plugin/avro/GenerateAvroProtocolTask.java
@@ -20,8 +20,10 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 import org.apache.avro.Protocol;
 import org.apache.avro.compiler.idl.Idl;
 import org.apache.avro.compiler.idl.ParseException;
@@ -41,10 +43,12 @@ import static com.github.davidmc24.gradle.plugin.avro.Constants.IDL_EXTENSION;
 public class GenerateAvroProtocolTask extends OutputDirTask {
 
     private FileCollection classpath;
+    private Set<String> processedFiles;
 
     public GenerateAvroProtocolTask() {
         super();
         this.classpath = GradleCompatibility.createConfigurableFileCollection(getProject());
+        this.processedFiles = new HashSet<String>();
     }
 
     public void setClasspath(FileCollection classpath) {
@@ -89,11 +93,15 @@ public class GenerateAvroProtocolTask extends OutputDirTask {
         getLogger().info("Processing {}", idlFile);
         try (Idl idl = new Idl(idlFile, loader)) {
             Protocol protocol = idl.CompilationUnit();
+            String filePath = AvroUtils.assemblePath(protocol);
+            if (!processedFiles.add(filePath)) {
+                throw new GradleException("File already processed with same namespace and protocol name.");
+            }
             File protoFile = new File(getOutputDir().get().getAsFile(), AvroUtils.assemblePath(protocol));
             String protoJson = protocol.toString(true);
             FileUtils.writeJsonFile(protoFile, protoJson);
             getLogger().debug("Wrote {}", protoFile.getPath());
-        } catch (IOException | ParseException ex) {
+        } catch (IOException | ParseException | GradleException ex) {
             throw new GradleException(String.format("Failed to compile IDL file %s", idlFile), ex);
         }
     }

--- a/src/test/groovy/com/github/davidmc24/gradle/plugin/avro/GenerateAvroProtocolTaskFunctionalSpec.groovy
+++ b/src/test/groovy/com/github/davidmc24/gradle/plugin/avro/GenerateAvroProtocolTaskFunctionalSpec.groovy
@@ -91,4 +91,20 @@ class GenerateAvroProtocolTaskFunctionalSpec extends FunctionalSpec {
         projectFile("build/generated-main-avro-avpr/org/example/v1/TestProtocol.avpr").file
         projectFile("build/generated-main-avro-avpr/org/example/v2/TestProtocol.avpr").file
     }
+
+    def "fails if avpr will be overwritten"() {
+        given: "a project with two IDL files with the same protocol name and namespace"
+        applyAvroPlugin()
+
+        copyResource("namespaced-idl/v1/test.avdl", projectFolder("src/main/avro/v1"))
+        copyResource("namespaced-idl/v1/test_same_protocol.avdl", projectFolder("src/main/avro/v1"))
+
+        when: "running the task"
+        run("generateAvroProtocol")
+
+        then:
+        def ex = thrown(Exception)
+        ex.message.contains("Failed to compile IDL file")
+        ex.message.contains("File already processed with same namespace and protocol name.")
+    }
 }

--- a/src/test/resources/com/github/davidmc24/gradle/plugin/avro/namespaced-idl/v1/test_same_protocol.avdl
+++ b/src/test/resources/com/github/davidmc24/gradle/plugin/avro/namespaced-idl/v1/test_same_protocol.avdl
@@ -1,0 +1,6 @@
+@namespace("org.example.v1")
+protocol TestProtocol {
+    record SomeOtherTestRecord {
+        string field1;
+    }
+}


### PR DESCRIPTION
When IDL files use the same namespace and protocol the avpr files will get overwritten.  It seems like this should cause an error.