### PR TITLE
Add ability to use conversions and type factories residing outside of build classpath

### DIFF
--- a/src/main/java/com/github/davidmc24/gradle/plugin/avro/AvroBasePlugin.java
+++ b/src/main/java/com/github/davidmc24/gradle/plugin/avro/AvroBasePlugin.java
@@ -38,8 +38,11 @@ public class AvroBasePlugin implements Plugin<Project> {
             task.isGettersReturnOptional().convention(avroExtension.isGettersReturnOptional());
             task.isOptionalGettersForNullableFieldsOnly().convention(avroExtension.isOptionalGettersForNullableFieldsOnly());
             task.isEnableDecimalLogicalType().convention(avroExtension.isEnableDecimalLogicalType());
+            task.getConversionsAndTypeFactoriesClasspath().from(avroExtension.getConversionsAndTypeFactoriesClasspath());
             task.getLogicalTypeFactories().convention(avroExtension.getLogicalTypeFactories());
+            task.getLogicalTypeFactoryClassNames().convention(avroExtension.getLogicalTypeFactoryClassNames());
             task.getCustomConversions().convention(avroExtension.getCustomConversions());
+            task.getCustomConversionClassNames().convention(avroExtension.getCustomConversionClassNames());
         });
     }
 }

--- a/src/main/java/com/github/davidmc24/gradle/plugin/avro/AvroExtension.java
+++ b/src/main/java/com/github/davidmc24/gradle/plugin/avro/AvroExtension.java
@@ -17,6 +17,7 @@ package com.github.davidmc24.gradle.plugin.avro;
 
 import org.apache.avro.Conversion;
 import org.apache.avro.LogicalTypes;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -33,8 +34,13 @@ public interface AvroExtension {
     Property<Boolean> isGettersReturnOptional();
     Property<Boolean> isOptionalGettersForNullableFieldsOnly();
     Property<Boolean> isEnableDecimalLogicalType();
+    ConfigurableFileCollection getConversionsAndTypeFactoriesClasspath();
     MapProperty<String, Class<? extends LogicalTypes.LogicalTypeFactory>> getLogicalTypeFactories();
+    MapProperty<String, String> getLogicalTypeFactoryClassNames();
     ListProperty<Class<? extends Conversion<?>>> getCustomConversions();
+    ListProperty<String> getCustomConversionClassNames();
     AvroExtension logicalTypeFactory(String typeName, Class<? extends LogicalTypes.LogicalTypeFactory> typeFactoryClass);
+    AvroExtension logicalTypeFactory(String typeName, String typeFactoryClassName);
     AvroExtension customConversion(Class<? extends Conversion<?>> conversionClass);
+    AvroExtension customConversion(String conversionClassName);
 }

--- a/src/main/java/com/github/davidmc24/gradle/plugin/avro/Constants.java
+++ b/src/main/java/com/github/davidmc24/gradle/plugin/avro/Constants.java
@@ -41,7 +41,9 @@ class Constants {
     static final boolean DEFAULT_OPTIONAL_GETTERS_FOR_NULLABLE_FIELDS_ONLY = false;
     static final boolean DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE = true;
     static final Map<String, Class<? extends LogicalTypes.LogicalTypeFactory>> DEFAULT_LOGICAL_TYPE_FACTORIES = Collections.emptyMap();
+    static final Map<String, String> DEFAULT_LOGICAL_TYPE_FACTORY_CLASS_NAMES = Collections.emptyMap();
     static final List<Class<? extends Conversion<?>>> DEFAULT_CUSTOM_CONVERSIONS = Collections.emptyList();
+    static final List<String> DEFAULT_CUSTOM_CONVERSION_CLASS_NAMES = Collections.emptyList();
 
     static final String SCHEMA_EXTENSION = "avsc";
     static final String PROTOCOL_EXTENSION = "avpr";

--- a/src/main/java/com/github/davidmc24/gradle/plugin/avro/GenerateAvroJavaTask.java
+++ b/src/main/java/com/github/davidmc24/gradle/plugin/avro/GenerateAvroJavaTask.java
@@ -23,14 +23,17 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.charset.Charset;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import org.apache.avro.Conversion;
 import org.apache.avro.LogicalTypes;
+import org.apache.avro.LogicalTypes.LogicalTypeFactory;
 import org.apache.avro.Protocol;
 import org.apache.avro.Schema;
 import org.apache.avro.compiler.specific.SpecificCompiler;
@@ -38,6 +41,7 @@ import org.apache.avro.compiler.specific.SpecificCompiler.FieldVisibility;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericData.StringType;
 import org.gradle.api.GradleException;
+import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.model.ObjectFactory;
@@ -73,8 +77,11 @@ public class GenerateAvroJavaTask extends OutputDirTask {
     private final Property<Boolean> createSetters;
     private final Property<Boolean> enableDecimalLogicalType;
     private FileCollection classpath;
+    private final ConfigurableFileCollection conversionsAndTypeFactoriesClasspath;
     private final MapProperty<String, Class<? extends LogicalTypes.LogicalTypeFactory>> logicalTypeFactories;
+    private final MapProperty<String, String> logicalTypeFactoryClassNames;
     private final ListProperty<Class<? extends Conversion<?>>> customConversions;
+    private final ListProperty<String> customConversionClassNames;
 
     private final Provider<StringType> stringTypeProvider;
     private final Provider<FieldVisibility> fieldVisibilityProvider;
@@ -98,10 +105,15 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         this.createSetters = objects.property(Boolean.class).convention(Constants.DEFAULT_CREATE_SETTERS);
         this.enableDecimalLogicalType = objects.property(Boolean.class).convention(Constants.DEFAULT_ENABLE_DECIMAL_LOGICAL_TYPE);
         this.classpath = GradleCompatibility.createConfigurableFileCollection(getProject());
+        this.conversionsAndTypeFactoriesClasspath = GradleCompatibility.createConfigurableFileCollection(getProject());
         this.logicalTypeFactories = objects.mapProperty(String.class, Constants.LOGICAL_TYPE_FACTORY_TYPE.getConcreteClass())
             .convention(Constants.DEFAULT_LOGICAL_TYPE_FACTORIES);
+        this.logicalTypeFactoryClassNames = objects.mapProperty(String.class, String.class)
+            .convention(Constants.DEFAULT_LOGICAL_TYPE_FACTORY_CLASS_NAMES);
         this.customConversions =
             objects.listProperty(Constants.CONVERSION_TYPE.getConcreteClass()).convention(Constants.DEFAULT_CUSTOM_CONVERSIONS);
+        this.customConversionClassNames =
+            objects.listProperty(String.class).convention(Constants.DEFAULT_CUSTOM_CONVERSION_CLASS_NAMES);
         this.stringTypeProvider = getStringType()
             .map(input -> Enums.parseCaseInsensitive(Constants.OPTION_STRING_TYPE, StringType.values(), input));
         this.fieldVisibilityProvider = getFieldVisibility()
@@ -249,6 +261,12 @@ public class GenerateAvroJavaTask extends OutputDirTask {
     }
 
     @Optional
+    @Classpath
+    public ConfigurableFileCollection getConversionsAndTypeFactoriesClasspath() {
+        return conversionsAndTypeFactoriesClasspath;
+    }
+
+    @Optional
     @Input
     public MapProperty<String, Class<? extends LogicalTypes.LogicalTypeFactory>> getLogicalTypeFactories() {
         return logicalTypeFactories;
@@ -264,6 +282,22 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         this.logicalTypeFactories.set(logicalTypeFactories);
     }
 
+    @Input
+    @Optional
+    public MapProperty<String, String> getLogicalTypeFactoryClassNames() {
+        return logicalTypeFactoryClassNames;
+    }
+
+    public void setLogicalTypeFactoryClassNames(Provider<? extends Map<? extends String,
+        ? extends String>> provider) {
+        this.logicalTypeFactoryClassNames.set(provider);
+    }
+
+    public void setLogicalTypeFactoryClassNames(Map<? extends String,
+        ? extends String> logicalTypeFactoryClassNames) {
+        this.logicalTypeFactoryClassNames.set(logicalTypeFactoryClassNames);
+    }
+
     @Optional
     @Input
     public ListProperty<Class<? extends Conversion<?>>> getCustomConversions() {
@@ -276,6 +310,20 @@ public class GenerateAvroJavaTask extends OutputDirTask {
 
     public void setCustomConversions(Iterable<Class<? extends Conversion<?>>> customConversions) {
         this.customConversions.set(customConversions);
+    }
+
+    @Optional
+    @Input
+    public ListProperty<String> getCustomConversionClassNames() {
+        return customConversionClassNames;
+    }
+
+    public void setCustomConversionClassNames(Provider<Iterable<String>> provider) {
+        this.customConversionClassNames.set(provider);
+    }
+
+    public void setCustomConversionClassNames(Iterable<String> customConversionClassNames) {
+        this.customConversionClassNames.set(customConversionClassNames);
     }
 
     @TaskAction
@@ -397,7 +445,7 @@ public class GenerateAvroJavaTask extends OutputDirTask {
      * Since {@link LogicalTypes} is a static registry, this may result in side-effects.
      */
     private void registerLogicalTypes() {
-        Map<String, Class<? extends LogicalTypes.LogicalTypeFactory>> logicalTypeFactoryMap = logicalTypeFactories.get();
+        Map<String, Class<? extends LogicalTypes.LogicalTypeFactory>> logicalTypeFactoryMap = resolveLocalTypeFactories();
         Set<Map.Entry<String, Class<? extends LogicalTypes.LogicalTypeFactory>>> logicalTypeFactoryEntries =
             logicalTypeFactoryMap.entrySet();
         for (Map.Entry<String, Class<? extends LogicalTypes.LogicalTypeFactory>> entry : logicalTypeFactoryEntries) {
@@ -412,8 +460,59 @@ public class GenerateAvroJavaTask extends OutputDirTask {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    private Map<String, Class<? extends LogicalTypes.LogicalTypeFactory>> resolveLocalTypeFactories() {
+        Map<String, Class<? extends LogicalTypes.LogicalTypeFactory>> result = new HashMap<>();
+        if (logicalTypeFactoryClassNames.isPresent()) {
+            ClassLoader typeFactoriesClassLoader = createConversionsAndTypeFactoriesClassLoader();
+            for (Entry<String, String> entry : logicalTypeFactoryClassNames.get().entrySet()) {
+                String logicalTypeFactoryClassName = entry.getValue();
+                try {
+                    Class<?> aClass = Class.forName(logicalTypeFactoryClassName, true, typeFactoriesClassLoader);
+                    result.put(entry.getKey(), (Class<? extends LogicalTypeFactory>) aClass);
+                } catch (ClassNotFoundException e) {
+                    throw new RuntimeException("Unable to load logical type factory class " + logicalTypeFactoryClassName, e);
+                }
+            }
+        }
+        result.putAll(logicalTypeFactories.get());
+        return result;
+    }
+
     private void registerCustomConversions(SpecificCompiler compiler) {
+        loadCustomConversionClasses().forEach(compiler::addCustomConversion);
         customConversions.get().forEach(compiler::addCustomConversion);
+    }
+
+    private List<Class<?>> loadCustomConversionClasses() {
+        if (customConversionClassNames.isPresent()) {
+            ClassLoader customConversionsClassLoader = createConversionsAndTypeFactoriesClassLoader();
+            return customConversionClassNames.get().stream()
+                .map(conversionClassName -> {
+                    try {
+                        return Class.forName(conversionClassName, true, customConversionsClassLoader);
+                    } catch (ClassNotFoundException e) {
+                        throw new RuntimeException("Unable to load custom conversion class " + conversionClassName, e);
+                    }
+                }).collect(Collectors.toList());
+        } else {
+            return Collections.emptyList();
+        }
+    }
+
+    private ClassLoader createConversionsAndTypeFactoriesClassLoader() {
+        URL[] urls = conversionsAndTypeFactoriesClasspath.getFiles().stream()
+            .map(File::toURI)
+            .map(uri -> {
+                try {
+                    return uri.toURL();
+                } catch (MalformedURLException e) {
+                    throw new RuntimeException("Unable to resolve URL in conversions and type factories classpath", e);
+                }
+            })
+            .toArray(URL[]::new);
+
+        return new URLClassLoader(urls, getClass().getClassLoader());
     }
 
     private ClassLoader assembleClassLoader() {

--- a/src/main/java/com/github/davidmc24/gradle/plugin/avro/GradleCompatibility.java
+++ b/src/main/java/com/github/davidmc24/gradle/plugin/avro/GradleCompatibility.java
@@ -32,7 +32,7 @@ class GradleCompatibility {
         if (GradleFeatures.extensionInjection.isSupported()) {
             return project.getExtensions().create(extensionName, extensionType);
         } else {
-            return project.getExtensions().create(extensionName, extensionType, project.getObjects());
+            return project.getExtensions().create(extensionName, extensionType, project, project.getObjects());
         }
     }
 


### PR DESCRIPTION
This is needed for when the conversions and/or type factories that are being configured for use by the plugin are part of the same build and you end up with a chicken and egg problem forcing you to using trickery in `buildSrc` (this is actually exposed by existing tests in [`CustomConversionFunctionalSpec`](https://github.com/davidmc24/gradle-avro-plugin/blob/master/src/test/groovy/com/github/davidmc24/gradle/plugin/avro/CustomConversionFunctionalSpec.groovy). Hopefully the [test I added](https://github.com/davidmc24/gradle-avro-plugin/commit/c1651198e0f795fee7b79133f23eac32037e92fe#diff-b6d697ce9c603d8ed2be90b0987c81490d2bc8d30c8759a33906af5e492558f4) documents the use case and proves that the changes are working as intended.

I tried hard for this to be up to scratch. I did a basic compatibility check ((thanks for making that easy) which forced me to change my initial implementation slightly to account for Gradle 5.1. I will keep my eye on the pipeline and address any failures. 

Please be informed that I will address any feedback within one business day at the most. I would really like to have this merged and released so I will gladly collaborate on making this happen.

I know this project is in maintenance mode, @davidmc24, so I'm sorry to be opening a PR but it already mostly does the job for us apart from the issue addressed by this PR so I'd rather contribute than reinvent the wheel.