### PR TITLE
Fix Kotlin DSL setup snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ avro {
     isCreateSetters.set(true)
     isCreateOptionalGetters.set(false)
     isGettersReturnOptional.set(false)
-    isOptionalGettersForNullableFieldsOnly(false)
+    isOptionalGettersForNullableFieldsOnly.set(false)
     fieldVisibility.set("PUBLIC_DEPRECATED")
     outputCharacterEncoding.set("UTF-8")
     stringType.set("String")


### PR DESCRIPTION
Trying out with a Kotlin DSL project returns this error with the existing snippet
```
e: build.gradle.kts:52:44: Too many arguments for public open fun isOptionalGettersForNullableFieldsOnly(): Property<Boolean!>! defined in com.github.davidmc24.gradle.plugin.avro.DefaultAvroExtension
```

After the change it runs fine (like all other property setters)